### PR TITLE
Allow branch to be set with environment variable

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,13 +1,13 @@
 set :rails_env, :staging
-set :branch, :master
-set :deploy_to, "/var/www/sites/archives/rails/cma-archives/"
+set :branch, ENV.fetch("CAPISTRANO_BRANCH", "master")
+set :deploy_to, "/var/www/sites/arapp-test/apps/cma-archives/"
 set :log_level, :info
 
 # server-based syntax
 # ======================
 # Defines a single server with a list of roles and multiple properties.
 # You can define all roles on a single server, or split them:
-server 'appdev01.clevelandart.org', user: 'railsapps', roles: %w{app db web workers}
+server 'arapp-test.clevelandart.org', user: 'railsapp', roles: %w{app db web workers}
 
 # Configuration
 # =============


### PR DESCRIPTION
Allow for staging environment to be set with an variable instead of hard coded so that different teset branches can be deployed for testing without affecting production updates