### PR TITLE
Add new image processors based on VIPS for faster performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ group :development do
   gem 'quiet_assets'
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'ruby-vips'
 end
 
 group :test do 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -584,6 +584,8 @@ GEM
       oauth2
     ruby-prof (0.16.2)
     ruby-progressbar (1.9.0)
+    ruby-vips (2.0.9)
+      ffi (~> 1.9)
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.5.3)
@@ -792,6 +794,7 @@ DEPENDENCIES
   rsolr (~> 1.0.6)
   rspec-rails
   ruby-prof
+  ruby-vips
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   simplecov

--- a/app/assets/stylesheets/cma_archives.scss
+++ b/app/assets/stylesheets/cma_archives.scss
@@ -93,6 +93,10 @@
   .collection-icon {
     text-align: left;
   }
+
+  figure {
+    max-width: 100%;
+  }
 }
 
 /* Reset over Sufia's defaults */

--- a/app/models/concerns/cma/generic_file/derivatives.rb
+++ b/app/models/concerns/cma/generic_file/derivatives.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 module CMA
 	module GenericFile
 		module Derivatives
@@ -6,20 +8,44 @@ module CMA
       included do
       	makes_derivatives do |obj|
           logger.info("[DERIVATIVES] Preparing to convert a(n) #{obj.mime_type}")
+ 
      	  case obj.mime_type
+          when *layered_image_mime_types
+    	    obj.transform_file :content, 
+              { 
+                access: { 
+                  format: 'jpg',    						
+                  height: 800,
+                  width: 1200,
+                  datastream: 'access'
+                },
+                thumbnail: { 
+                  format: 'jpg',                
+                  height: 200,
+                  width: 300,
+                  crop: true,
+                  strip_metadata: true,
+                  datastream: 'thumbnail'
+                }
+             }, processor: :vips_layered_image
           when *image_mime_types
-    		obj.transform_file :content, { 
-              access: { 
-                format: 'jpg',    						
-                size: '@1200000',
-    		    datastream: 'access'
-    		  },
-              thumbnail: { 
-                format: 'jpg',                
-                size: '@30000',
-                datastream: 'thumbnail'
-              },
-    		}, processor: :exif_image
+    	    obj.transform_file :content, 
+              { 
+                access: { 
+                  format: 'jpg',    						
+                  height: 800,
+                  width: 1200,
+                  datastream: 'access'
+                },
+                thumbnail: { 
+                  format: 'jpg',                
+                  height: 200,
+                  width: 300,
+                  crop: true,
+                  strip_metadata: true,
+                  datastream: 'thumbnail'
+                }
+             }, processor: :vips_image
           end
         end
 

--- a/app/models/concerns/cma/generic_file/mime_types.rb
+++ b/app/models/concerns/cma/generic_file/mime_types.rb
@@ -5,8 +5,13 @@ module CMA
 
       module ClassMethods
       	def image_mime_types
-      		['image/tiff', 'image/jpeg', 'image/x-adobe-dng']
+      	  ['image/tiff', 'image/jpeg', 'image/x-adobe-dng',
+           'image/vnd.adobe.photoshop']
       	end
+
+        def layered_image_mime_types
+          ['image/tiff', 'image/x-adobe-dng', 'image/vnd.adobe.photoshop']
+        end
       end
     end
   end

--- a/app/processors/hydra/derivatives/vips_image.rb
+++ b/app/processors/hydra/derivatives/vips_image.rb
@@ -1,0 +1,60 @@
+require 'ruby-vips'
+require 'pry'
+
+module Hydra::Derivatives
+  class VipsImage < Image
+    class_attribute :timeout
+
+    def process_without_timeout
+      directives.each do |name, args|
+        opts = args.kind_of?(Hash) ? args : {height: args}
+        format = opts.fetch(:format, 'jpg')
+        output_file_name = opts.fetch(:datastream, output_file_id(name))
+        create_resized_image output_file(output_file_name), format, opts
+      end
+    end
+
+    def create_resized_image output_file, format, opts
+      img_derivative = create_image output_file, format, opts
+      write_image output_file, img_derivative, opts
+      output_file.mime_type = new_mime_type(format)
+      output_file.original_name = "derivative.#{format}"
+    end
+
+    # Relies on VIPS instead of ImageMagick / GraphicsMagick to do processing
+    # with a simplified chain that makes several assumptions. The crops are
+    # done in two passes to ensure that the width and scale are correct in lieu
+    # of making a long narrow image for unusually wide images
+    #
+    # Aspect ratio is maintained as 2:3 so that if size is set to 400 pixels
+    # the width will be no more than 600 pixels 
+    def create_image output_file, format, opts
+      width = opts.fetch(:width, opts[:height]*1.5)
+
+      if (opts[:crop])
+        img_derivative = Vips::Image.thumbnail_buffer(source_file.content,
+          1000000, height: opts[:height], auto_rotate: true)
+        # Centre is used for smartcrop due to an issue with JPEGs that will
+        # otherwise break the process with an Out of Tile error
+        if (width < img_derivative.width)
+          img_derivative = img_derivative.smartcrop(width, opts[:height],
+            interesting: 'centre')
+        end
+      else
+        img_derivative = Vips::Image.thumbnail_buffer(source_file.content,
+          width, height: opts[:height], auto_rotate: true)
+      end
+  
+      return img_derivative
+    end
+  
+    def write_image output_file, image, opts
+      extension = opts.fetch(:format, "png")
+      format = ".#{extension}"
+      strip_flag = opts.fetch(:strip_metadata, false)
+
+      buffer = image.write_to_buffer(format, strip: strip_flag)
+      output_file.content = buffer
+    end
+  end
+end

--- a/app/processors/hydra/derivatives/vips_layered_image.rb
+++ b/app/processors/hydra/derivatives/vips_layered_image.rb
@@ -1,0 +1,29 @@
+require 'ruby-vips'
+require 'pry'
+
+module Hydra::Derivatives
+  class VipsLayeredImage < VipsImage
+    def create_image output_file, format, opts
+      width = opts.fetch(:width, opts[:height]*1.5)
+   
+      img_derivative = nil
+      TempfileService.create(source_file) do |tmp|
+        if (opts[:crop])
+          img_derivative = Vips::Image.thumbnail("#{tmp.path}[0]",
+            1000000, height: opts[:height], auto_rotate: true)
+          # Centre is used for smartcrop due to an issue with JPEGs that will
+          # otherwise break the process with an Out of Tile error
+          if (width < img_derivative.width)
+            img_derivative = img_derivative.smartcrop(width, opts[:height],
+              interesting: 'centre')
+          end
+        else
+          img_derivative = Vips::Image.thumbnail("#{tmp.path}[0]",
+            width, height: opts[:height], auto_rotate: true)
+        end
+      end
+
+      return img_derivative
+    end
+  end
+end

--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,7 +1,7 @@
 <%# Override Blacklight defaults %>
 <div class="document">
   <figure>
-    <%= render_thumbnail_tag(document, {}, :counter => document_counter_with_offset(document_counter)) %>
+    <%= render_thumbnail_tag(document, {class: "img-responsive"}, :counter => document_counter_with_offset(document_counter)) %>
     <figcaption>
       <%= render_document_partials document, blacklight_config.view_config(:gallery).partials %>
     </figcaption>


### PR DESCRIPTION
Add new image handlers which rely on VIPS for faster performance over ImageMagick or GraphicsMagick when doing conversions. This update has been tested with ruby-vips 2.x and VIPS 8.5.9. 

Known issues include potential slowdowns when handling PSB / PSD images larger than 5GB and trouble with malformed TIFFs. A future pull request could add more robust handling for edge cases to work around these existing problems.