### PR TITLE
Ldap auth

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -5,12 +5,12 @@ Devise.setup do |config|
   config.ldap_logger = true
   #config.ldap_create_user = false
   config.ldap_update_password = false
-  #config.ldap_config = "#{Rails.root}/config/ldap.yml"
+  config.ldap_config = "#{Rails.root}/config/ldap.yml"
   #config.ldap_check_group_membership = false
   config.ldap_auth_username_builder = Proc.new() { |attribute, login, ldap| "#{login}@clevelandart.org" }
   #config.ldap_check_group_membership_without_admin = false
   #config.ldap_check_attributes = false
-  config.ldap_use_admin_to_bind = true
+  config.ldap_use_admin_to_bind = false
   #config.ldap_ad_group_check = false
 
   # The secret key used by Devise. Devise uses this key to generate

--- a/spec/jobs/ingest_local_file_job_spec.rb
+++ b/spec/jobs/ingest_local_file_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe IngestLocalFileJob do
       file.reload
 
       expect(File.exists? resource_path).to eq true
-      expect(file.content.mime_type).to eq "message/external_body; access-type=URL; url=\"http://localhost:3000/downloads/#{file.id}\""
+      expect(file.content.mime_type).to eq "message/external_body;access-type=URL;url=\"http://localhost:3000/downloads/#{file.id}\""
       expect(file.content.original_name).to eq "lagoon.tif"
       expect(file.content.size).to eq 109216
 


### PR DESCRIPTION
Stop using administrative user to do LDAP lookups

Also fixes a bug in a Fedora spec tied to return MIME type for external content